### PR TITLE
add tzdata to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:latest
 RUN apk update && \
-    apk --no-cache add ca-certificates
+    apk --no-cache add \
+	ca-certificates \
+	tzdata
 
 ONBUILD WORKDIR /
 ONBUILD COPY --from=0 /repo/build app

--- a/migrations/Dockerfile
+++ b/migrations/Dockerfile
@@ -1,6 +1,8 @@
 FROM alpine:latest
 RUN apk update && \
-    apk --no-cache add ca-certificates
+    apk --no-cache add \
+	ca-certificates \
+	tzdata
 
 ENV MIGRATIONS_URL=file://migrations
 


### PR DESCRIPTION
Currently, our multi-stage build only adds tzdata to the first stage
image, alpine-golang. This alpine-service image is the second stage of
the build and does not copy the tzdata from the first stage. As a
result, I believe the tzdata may be available when we are building the
app itself in alpine-golang, but not available during runtime in
alpine-service. Go's time.LoadLocation may be used to load timezone info
during runtime, and is likely to be a critical requirement of that code
path.

This change adds tzdata to the alpine-service image(s), including
alpine-service:migrations. This should ensure that tzdata is available
to our apps at runtime.